### PR TITLE
:arrow_up: 升级 Kotlin 与构建依赖

### DIFF
--- a/cyxbs-applications/pro/AppNav.md
+++ b/cyxbs-applications/pro/AppNav.md
@@ -1,0 +1,275 @@
+# AppNav Deeplink 汇总
+
+> 打包时由 build-logic/manager/nav.AppNavReportTask 自动生成
+> 该文件需要被 git 提交用于后续使用
+
+- versionCode: 94
+- versionName: 6.10.6-alpha
+
+## 调试方法
+
+使用 idea 文档中的 ▶ 运行下面脚本，输入要测试的 deeplink
+
+### Windows / macOS / Linux
+
+> win 没 bash 可使用终端运行 PowerShell 版
+
+idea 中点击左侧 ▶ 可直接运行
+```sh
+#!/usr/bin/env bash
+while true; do
+  printf "输入 deeplink (回车退出): "
+  read -r link
+  [ -z "$link" ] && break
+  adb shell am start -a android.intent.action.VIEW -d "$link"
+done
+```
+
+### Windows (PowerShell 版)
+
+```powershell
+while ($true) {
+  $link = Read-Host "输入 deeplink (回车退出)"
+  if ([string]::IsNullOrEmpty($link)) { break }
+  adb shell am start -a android.intent.action.VIEW -d "$link"
+}
+```
+
+## 模板说明
+
+URL 模板用 `{}` / `[]` 区分 required / optional，object fields 段递归展开复杂结构。
+
+### URL 模板
+
+- `name={Type}` — required 字段，调用方必须提供
+- `name=[Type]` — optional 字段（构造参数有默认值），调用方可省略
+- 类型末尾的 `?` 表示 Kotlin nullable，值允许为 null（与 optional 不同：nullable 仍要求字段出现）
+- 集合 / Map 直接以原始 Kotlin 类型出现，例如 `{List<TextInfo>}`、`{Map<String, TextInfo>}`，编码方式遵循 kotlinx.serialization JSON 形式
+
+### object fields
+
+仅当字段含可展开的内部结构时才会出现。展开规则：
+
+- `name: Type` — required 字段，`[name]: Type` — optional 字段
+- 普通 `@Serializable` 类：列出每个非 `@Transient` 的主构造参数
+- `enum`：列出所有 entry 名
+- `Map<K, V>`：展开为 `value: V { ... }`（仅 V 是复杂类型时才进一步展开）
+- `Collection<E>` / `Array<E>`：展开为 `value: E { ... }`
+- 带类型形参的类（如 `Wrapper<T>`）：按外层泛型实参替换 `T` 后再展开
+
+### 示例
+
+```text
+deeplink: cyxbs://test/abc?title={String}&content={String}&map=[Map<String, TextInfo>]&button=[ButtonInfo?]
+object fields:
+  [map]: Map<String, TextInfo> {
+    value: TextInfo {
+      text: String
+      [isBold]: Boolean
+    }
+  }
+  [button]: ButtonInfo? {
+    text: String
+    [action]: String?
+  }
+```
+
+解读：`title` / `content` 必填；`map` 可省略，若提供则为 `Map<String, TextInfo>` 的 JSON；`button` 可省略且允许为 null。`TextInfo` 中只有 `text` 必填，其它字段可省略。
+
+## :cyxbs-functions:update
+
+### dialog/update
+
+- entry: `com.cyxbs.functions.update.dialog.UpdateInfoDialogNavEntry`
+- argument: `com.cyxbs.functions.update.dialog.UpdateInfoNavArgument`
+
+```text
+deeplink: cyxbs://dialog/update?versionName={String}&updateContent={String}&downloadUrl={String}
+```
+
+## :cyxbs-pages:course
+
+### course
+
+- entry: `com.cyxbs.pages.course.CourseNavEntry`
+- argument: `com.cyxbs.pages.course.api.CourseNavArgument`
+
+```text
+deeplink: cyxbs://course?stuNum={String}&stableKey=[String?]
+```
+
+### course_find
+
+- entry: `com.cyxbs.pages.course.find.FindCourseNavEntry`
+- argument: `com.cyxbs.pages.course.api.FindCourseNavArgument`
+
+```text
+deeplink: cyxbs://course_find?initialQuery=[String]
+```
+
+## :cyxbs-pages:emptyroom
+
+### emptyroom
+
+- entry: `com.cyxbs.pages.emptyroom.ui.EmptyRoomNavEntry`
+- argument: `com.cyxbs.pages.emptyroom.api.EmptyRoomNavArgument`
+
+```text
+deeplink: cyxbs://emptyroom
+```
+
+## :cyxbs-pages:food
+
+### food
+
+- entry: `com.cyxbs.pages.food.ui.FoodNavEntry`
+- argument: `com.cyxbs.pages.food.api.FoodNavArgument`
+
+```text
+deeplink: cyxbs://food
+```
+
+## :cyxbs-pages:home
+
+### home
+
+- entry: `com.cyxbs.pages.home.ui.HomeNavDestination`
+- argument: `com.cyxbs.pages.home.api.HomeNavArgument`
+
+```text
+deeplink: cyxbs://home?page=[String]
+```
+
+## :cyxbs-pages:login
+
+### login
+
+- entry: `com.cyxbs.pages.login.ui.LoginNavEntry`
+- argument: `com.cyxbs.pages.login.api.LoginNavArgument`
+
+```text
+deeplink: cyxbs://login?targetUrl=[String?]
+```
+
+## :cyxbs-pages:map
+
+### map
+
+- entry: `com.cyxbs.pages.map.ui.MapNavEntry`
+- argument: `com.cyxbs.pages.map.api.MapNavArgument`
+
+```text
+deeplink: cyxbs://map?placeSearch=[String?]
+```
+
+### map_show_picture
+
+- entry: `com.cyxbs.pages.map.ui.MapShowPictureNavEntry`
+- argument: `com.cyxbs.pages.map.ui.MapShowPictureNavArgument`
+
+```text
+deeplink: cyxbs://map_show_picture?imageList={List<String>}&currentIndex={Int}
+```
+
+### map_place_detail
+
+- entry: `com.cyxbs.pages.map.ui.PlaceDetailNavEntry`
+- argument: `com.cyxbs.pages.map.ui.PlaceDetailNavArgument`
+
+```text
+deeplink: cyxbs://map_place_detail
+```
+
+### map_search
+
+- entry: `com.cyxbs.pages.map.ui.SearchNavEntry`
+- argument: `com.cyxbs.pages.map.ui.SearchNavArgument`
+
+```text
+deeplink: cyxbs://map_search
+```
+
+## :cyxbs-pages:mine
+
+### about
+
+- entry: `com.cyxbs.pages.mine.about.ui.AboutNavEntry`
+- argument: `com.cyxbs.pages.mine.about.ui.AboutNavArgument`
+
+```text
+deeplink: cyxbs://about
+```
+
+### edit_info
+
+- entry: `com.cyxbs.pages.mine.edit.EditInfoNavEntry`
+- argument: `com.cyxbs.pages.mine.edit.EditInfoNavArgument`
+
+```text
+deeplink: cyxbs://edit_info
+```
+
+### sign
+
+- entry: `com.cyxbs.pages.mine.sign.ui.SignNavEntry`
+- argument: `com.cyxbs.pages.mine.sign.ui.SignNavArgument`
+
+```text
+deeplink: cyxbs://sign
+```
+
+## :cyxbs-pages:notification
+
+### dialog/notice
+
+- entry: `com.cyxbs.pages.notification.dialog.NoticeDialogNavEntry`
+- argument: `com.cyxbs.pages.notification.api.NoticeNavArgument`
+
+```text
+deeplink: cyxbs://dialog/notice?title={String}&content={String}&map=[Map<String, TextInfo>]&button=[ButtonInfo?]
+object fields:
+  [map]: Map<String, TextInfo> {
+    value: TextInfo {
+      text: String
+      [isBold]: Boolean
+      [textSize]: Int
+      [textColorStr]: String?
+      [action]: String?
+    }
+  }
+  [button]: ButtonInfo? {
+    text: String
+    [action]: String?
+  }
+```
+
+## :cyxbs-pages:schedule
+
+### schedule/edit
+
+- entry: `com.cyxbs.pages.schedule.ui.edit.EditScheduleDialogPreview`
+- argument: `com.cyxbs.pages.schedule.ui.edit.EditScheduleDialogNavArgument`
+
+```text
+deeplink: cyxbs://schedule/edit
+```
+
+### schedule
+
+- entry: `com.cyxbs.pages.schedule.ui.main.ScheduleMainNavEntry`
+- argument: `com.cyxbs.pages.schedule.api.ScheduleMainNavArgument`
+
+```text
+deeplink: cyxbs://schedule
+```
+
+## :cyxbs-pages:schoolcar
+
+### school_car
+
+- entry: `com.cyxbs.pages.schoolcar.ui.SchoolCarNavDestination`
+- argument: `com.cyxbs.pages.schoolcar.api.SchoolCarNavArgument`
+
+```text
+deeplink: cyxbs://school_car
+```

--- a/cyxbs-pages/affair/src/commonMain/kotlin/com/cyxbs/pages/affair/model/impl/AffairGroupModelImpl.kt
+++ b/cyxbs-pages/affair/src/commonMain/kotlin/com/cyxbs/pages/affair/model/impl/AffairGroupModelImpl.kt
@@ -95,12 +95,12 @@ class AffairGroupModelImpl(
   }
 
   fun addAffairInternal(idModel: AffairIdModelImpl) {
-    _itemList.value = itemList.value.add(idModel)
+    _itemList.value = itemList.value.adding(idModel)
     addedAffair.tryEmit(idModel)
   }
 
   fun removeAffairInternal(idModel: AffairIdModelImpl) {
-    val newList = itemList.value.remove(idModel)
+    val newList = itemList.value.removing(idModel)
     if (newList !== itemList.value) {
       _itemList.value = newList
       deletedAffair.tryEmit(idModel)

--- a/cyxbs-pages/affair/src/commonMain/kotlin/com/cyxbs/pages/affair/repos/AffairRepository2.kt
+++ b/cyxbs-pages/affair/src/commonMain/kotlin/com/cyxbs/pages/affair/repos/AffairRepository2.kt
@@ -176,9 +176,9 @@ object AffairRepository2 {
         val index = list.indexOfFirst { it.localId == newAffair.localId }
         if (index > 0) {
           // 已经存在，此时应该是本地临时事务的上传
-          list.set(index, newAffair)
+          list.replacingAt(index, newAffair)
         } else {
-          list.add(newAffair)
+          list.adding(newAffair)
         }
       }.also {
         saveAffair(stuNum, it)
@@ -239,7 +239,7 @@ object AffairRepository2 {
     }.onSuccess {
       editAffairList(stuNum) { list ->
         val index = list.indexOfFirst { it.localId == affair.localId }
-        list.set(index, affair)
+        list.replacingAt(index, affair)
       }.also {
         saveAffair(stuNum, it)
       }
@@ -285,7 +285,7 @@ object AffairRepository2 {
     }.onSuccess {
       editAffairList(stuNum) {
         val index = it.indexOfFirst { it.localId == localId }
-        it.removeAt(index)
+        it.removingAt(index)
       }.also {
         saveAffair(stuNum, it)
       }

--- a/cyxbs-pages/course/view/src/commonMain/kotlin/com/cyxbs/pages/course/view/item/impl/CourseAffairItem.kt
+++ b/cyxbs-pages/course/view/src/commonMain/kotlin/com/cyxbs/pages/course/view/item/impl/CourseAffairItem.kt
@@ -84,7 +84,7 @@ private fun CourseAffairItem.Content(
     bottomText = affairDateModel.idModel.content.mergeFlow.collectAsState("").value,
     textColor = LocalAppColors.current.tvLv2,
     backgroundColor = Color.Transparent,
-    modifierList = remember { createCourseDefaultModifierList().add(AffairBackgroundItemModifier) },
+    modifierList = remember { createCourseDefaultModifierList().adding(AffairBackgroundItemModifier) },
     onClick = onClick,
   )
 }

--- a/cyxbs-pages/noclass/src/androidMain/kotlin/com/cyxbs/pages/noclass/page/adapter/NoClassTemporaryAdapter.kt
+++ b/cyxbs-pages/noclass/src/androidMain/kotlin/com/cyxbs/pages/noclass/page/adapter/NoClassTemporaryAdapter.kt
@@ -58,7 +58,7 @@ class NoClassTemporaryAdapter : ListAdapter<Student,NoClassTemporaryAdapter.VH>(
         val tvId : TextView = itemView.findViewById(R.id.noclass_tv_member_id)
         val slideMenu : SlideMenuLayout = itemView.findViewById(R.id.noclass_item_group_member_slide_layout)
         init {
-            itemView.findViewById<TextView?>(R.id.noclass_item_tv_delete).apply {
+            itemView.findViewById<TextView>(R.id.noclass_item_tv_delete).apply {
                 setOnClickListener {
                     slideMenu.closeRightSlide()
                     val stu = getItem(bindingAdapterPosition)

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,3 +50,5 @@ kotlin.mpp.applyDefaultHierarchyTemplate=false
 cyxbs.multiplatform.ios=true
 cyxbs.multiplatform.web=true
 cyxbs.multiplatform.desktop=true
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,16 +24,16 @@ kotlinJvmTarget = "17"
 #                                            Android
 ####################################################################################################
 # https://developer.android.com/build/releases/gradle-plugin?hl=zh-cn
-agp = "9.2.1"
+agp = "9.3.1"
 android-compileSdk = "37"
 android-minSdk = "26"
 android-targetSdk = "37"
 # https://developer.android.com/jetpack/androidx/releases/appcompat
 androidx-appcompat = "1.7.1"
 # https://developer.android.com/jetpack/androidx/releases/lifecycle
-androidx-lifecycle = "2.10.0"
+androidx-lifecycle = "2.11.0"
 # https://developer.android.com/jetpack/androidx/releases/core
-androidx-core-ktx = "1.18.0"
+androidx-core-ktx = "1.19.0"
 # https://developer.android.com/jetpack/androidx/releases/core
 androidx-core-animation = "1.0.0"
 # https://developer.android.com/kotlin/ktx/extensions-list#androidxcollection
@@ -53,7 +53,7 @@ androidx-work = "2.11.2"
 #                                              控件
 ####################################################################################################
 # https://developer.android.com/jetpack/androidx/releases/constraintlayout
-androidx-constraintlayout = "2.2.1"
+androidx-constraintlayout = "2.2.2"
 # https://developer.android.com/jetpack/androidx/releases/recyclerview
 androidx-recyclerview = "1.4.0"
 # https://developer.android.com/jetpack/androidx/releases/cardview
@@ -87,27 +87,27 @@ dialog = "3.3.0" # 作者已停止维护
 wheelPicker = "1.1.3"
 # https://github.com/wangjiegulu/WheelView
 # 又一个滚轮选择器（为什么会有多个？我也不知道，但这个 17 年后就没维护了）
-wheelView = "4.1.9"
+wheelView = "4.1.15"
 
 ####################################################################################################
 #                                              Kotlin
 ####################################################################################################
 # https://github.com/JetBrains/kotlin/releases
-kotlin = "2.3.21"
+kotlin = "2.4.10"
 # https://github.com/google/ksp/releases
-ksp = "2.3.6" # ksp 版本与 kotlin 版本强绑定，升级 kotlin 记得去更 ksp
+ksp = "2.3.10" # KSP 2.3 起版本不再与 Kotlin 编译器版本绑定，但升级工具链时仍需验证兼容性
 # https://github.com/Kotlin/kotlinx.coroutines
 kotlinx-coroutines = "1.11.0"
 # https://github.com/Kotlin/kotlinx.collections.immutable
-kotlinx-collections = "0.4.0"
+kotlinx-collections = "0.5.1"
 # https://github.com/Kotlin/kotlinx.serialization
 kotlinx-serialization = "1.11.0"
 # https://github.com/Kotlin/kotlinx-datetime
 kotlinx-datetime = "0.8.0"
 # https://github.com/Kotlin/kotlinx-atomicfu
-kotlinx-atomicfu = "0.32.1"
+kotlinx-atomicfu = "0.33.0"
 # https://github.com/ktorio/ktor
-ktor = "3.5.0"
+ktor = "3.5.1"
 ########################################### KMP 第三方依赖 ###########################################
 # https://github.com/eygraber/uri-kmp
 kmp-uri = "0.0.21"
@@ -116,19 +116,19 @@ kmp-ktProvider = "1.5.0" # 985892345 的 kt 多平台跨模块服务提供框架
 # https://github.com/russhwolf/multiplatform-settings
 kmp-settings = "1.3.0"
 # https://github.com/Foso/Ktorfit
-kmp-ktorfit = "2.7.3"
+kmp-ktorfit = "2.7.5"
 
 
 ####################################################################################################
 #                                              Compose
 ####################################################################################################
 # https://github.com/JetBrains/compose-multiplatform/releases
-compose-multiplatform = "1.11.0"
+compose-multiplatform = "1.11.1"
 # 官网文档可能更新不及时，版本请看 compose 发布时给出的版本
 compose-navigation3 = "1.1.1"
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-lifecycle.html
 # 看 compose 发布时给出的版本
-compose-lifecycle = "2.11.0-beta01"
+compose-lifecycle = "2.11.0"
 # 看 compose 发布时给出的版本
 compose-savedstate = "1.4.0"
 # 看 compose 发布时给出的版本
@@ -138,15 +138,15 @@ compose-adaptive = "1.3.0-alpha07"
 # 多平台版本，非官方 https://github.com/Lavmee/constraintlayout-compose-multiplatform
 compose-constraintLayout = "0.7.0"
 # 官方约束布局，但只有安卓版本 https://developer.android.com/jetpack/androidx/releases/constraintlayout
-compose-constraintLayout-android = "1.1.1"
+compose-constraintLayout-android = "1.1.2"
 # https://github.com/alexzhirkevich/compottie
-compose-lottie = "2.1.0"
+compose-lottie = "2.2.4"
 
 ####################################################################################################
 #                                               三方库
 ####################################################################################################
 # https://developer.umeng.com/docs/67966/detail/206987
-umeng-common = "9.9.1"
+umeng-common = "9.9.6"
 umeng-asms = "1.8.7.2"
 umeng-push = "6.7.6"
 # https://github.com/Tencent/VasDolly
@@ -157,14 +157,14 @@ bugly = "4.1.9.3"
 # https://github.com/greenrobot/EventBus
 eventBus = "3.3.1"
 # https://github.com/bumptech/glide/releases
-glide = "5.0.7"
+glide = "5.0.9"
 # https://github.com/Yalantis/uCrop
 # 一个裁剪图片的库
 ucrop = "2.2.11-native"
 # https://github.com/square/retrofit
 retrofit = "3.0.0"
 # https://github.com/square/okhttp
-okhttp = "5.3.2"
+okhttp = "5.4.0"
 # https://github.com/google/gson
 gson = "2.14.0"
 # https://github.com/ReactiveX/RxJava
@@ -187,17 +187,17 @@ kotlinpoet = "2.3.0"
 # kmp大图浏览 https://github.com/jvziyaoyao/scale
 scale = "1.1.1-beta.3"
 # coil kmp网络图片加载框架 https://github.com/coil-kt/coil
-coil = "3.4.0"
+coil = "3.5.0"
 # filekit 跨平台的文件操作三方库 https://github.com/vinceglb/FileKit
-filekit = "0.14.1"
+filekit = "0.14.2"
 # 文件操作库 https://github.com/square/okio
-okio = "3.17.0"
+okio = "3.18.1"
 # 权限申请的第三方库 https://github.com/icerockdev/moko-permissions
 moko-permissions = "0.20.1"
 # 高德地图的定位 https://lbs.amap.com/api/android-location-sdk/guide/create-project/android-studio-create-project
-amap = "11.1.200"
+amap = "11.2.000"
 # 多平台 BuildConfig 生成 https://github.com/gmazzo/gradle-buildconfig-plugin
-buildconfig = "6.0.9"
+buildconfig = "6.0.10"
 
 [libraries]
 ####################################################################################################
@@ -413,6 +413,3 @@ views = [
     "material",
     "flexbox",
 ]
-
-
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,6 +2,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # AGP 与 gradle 版本对照：https://developer.android.com/build/releases/gradle-plugin?hl=zh-cn#updating-plugin
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- 升级 Gradle、AGP、Kotlin、Compose Multiplatform 及网络、图片和基础组件依赖。

- 迁移新版 kotlinx immutable collections 的 PersistentList 增删改 API。

- 修复 Kotlin 2.4 下 Android View 查找的空安全兼容问题，并保留 Desktop 与 Gradle 并行同步配置。

- 已通过 Android APK、Desktop、iOS 及相关公共源码集编译验证。

- 已完成 Scale/Skiko 桌面运行验证，暂未发现破坏性变更。