### PR TITLE
:bug: 优化查课搜索缓存、限流重试与异常提示

### DIFF
--- a/cyxbs-applications/multiplatform/src/desktopMain/kotlin/CyxbsDesktopApp.kt
+++ b/cyxbs-applications/multiplatform/src/desktopMain/kotlin/CyxbsDesktopApp.kt
@@ -7,10 +7,6 @@ import com.cyxbs.components.config.ConfigApplicationInfo
 import com.cyxbs.components.config.compose.theme.AppTheme
 import com.cyxbs.components.config.init.InitialManager
 import com.cyxbs.components.config.res.ConfigRes
-import com.cyxbs.components.base.webview.bindDesktopWebViewApplicationExit
-import com.cyxbs.components.base.webview.initializeDesktopWebViewRuntime
-import com.cyxbs.components.base.webview.prepareDesktopWebViewComposeInterop
-import com.cyxbs.components.base.webview.requestDesktopWebViewApplicationExit
 import com.cyxbs.components.init.runApp
 import com.cyxbs.components.navigation.AppNavDisplay
 import com.cyxbs.components.utils.extensions.PlatformToastCompose
@@ -27,20 +23,21 @@ import org.jetbrains.compose.resources.painterResource
  */
 
 fun main() {
-  prepareDesktopWebViewComposeInterop()
+//  prepareDesktopWebViewComposeInterop() // todo @zengzhaoxing 后续修护 desktop 上的 webView 接入问题
   runApp {
     MultiplatformKtProviderInitializer.tryInitKtProvider()
     InitialManager.init(isMainProcess = true)
     FileKit.init(appId = "com.mredrock.cyxbs")
-    initializeDesktopWebViewRuntime()
+//    initializeDesktopWebViewRuntime() // todo @zengzhaoxing 后续修护 desktop 上的 webView 接入问题
     launchApplication {
-      remember {
-        bindDesktopWebViewApplicationExit(::exitApplication)
-      }
+//      remember { // todo @zengzhaoxing 后续修护 desktop 上的 webView 接入问题
+//        bindDesktopWebViewApplicationExit(::exitApplication)
+//      }
       val width = 900
       val height = 600
       Window(
-        onCloseRequest = ::requestDesktopWebViewApplicationExit,
+//        onCloseRequest = ::requestDesktopWebViewApplicationExit, // todo @zengzhaoxing 后续修护 desktop 上的 webView 接入问题
+        onCloseRequest = ::exitApplication,
         title = "桌上重邮",
         state = rememberWindowState(width = width.dp, height = height.dp),
         icon = painterResource(ConfigRes.configIcAppLogo())

--- a/cyxbs-components/base/src/desktopMain/kotlin/com/cyxbs/components/base/webview/DesktopWebViewRuntime.kt
+++ b/cyxbs-components/base/src/desktopMain/kotlin/com/cyxbs/components/base/webview/DesktopWebViewRuntime.kt
@@ -33,7 +33,7 @@ fun requestDesktopWebViewApplicationExit() {
 /** 将 Chromium 的运行时和 Profile 固定在用户目录，避免污染工程目录或复用其他应用的默认 Profile。 */
 private fun CefAppBuilder.configureCefUserDataDirectory() {
   val rootDirectory = File(System.getProperty("user.home"), ".cyxbs/cef-user-data")
-  cefSettings.root_cache_path = rootDirectory.absolutePath
+//  cefSettings.root_cache_path = rootDirectory.absolutePath
   cefSettings.cache_path = File(rootDirectory, "default-profile").absolutePath
   cefSettings.persist_session_cookies = true
 }

--- a/cyxbs-pages/course/src/commonMain/kotlin/com/cyxbs/pages/course/find/ui/FindCourseScreen.kt
+++ b/cyxbs-pages/course/src/commonMain/kotlin/com/cyxbs/pages/course/find/ui/FindCourseScreen.kt
@@ -79,6 +79,11 @@ internal fun FindCourseScreen(
 
   val searchState by vm.searchState.collectAsState()
 
+  // 搜索异常是一次性提示事件，不参与内容状态切换，因此页面可以继续保留请求前的结果。
+  LaunchedEffect(vm) {
+    vm.toastEvent.collect { message -> toast(message) }
+  }
+
   // 统一返回逻辑：搜索状态非 Idle 时先清空输入回到 Idle，否则真正退出页面。
   // 由顶部栏返回按钮、系统返回键 / 手势 / ESC 共用
   val onBack: () -> Unit = {
@@ -174,10 +179,6 @@ private fun SearchBottomContent() {
 
       FindCourseViewModel.SearchState.Empty -> TopHintStatus {
         Text("查无此人", color = LocalAppColors.current.tvLv2, fontSize = 14.sp)
-      }
-
-      is FindCourseViewModel.SearchState.Error -> TopHintStatus {
-        Text(state.message, color = LocalAppColors.current.tvLv2, fontSize = 14.sp)
       }
 
       is FindCourseViewModel.SearchState.Success -> SearchResultList(
@@ -280,7 +281,7 @@ private fun SearchField(
 
 // IdleContent / LinkCard 已拆至同包 IdleContent.kt / LinkCard.kt
 
-/** 搜索框正下方一定距离的提示位（Loading / Empty / Error 共用），不再撑满剩余空间居中 */
+/** 搜索框正下方一定距离的提示位（Loading / Empty 共用），不再撑满剩余空间居中 */
 @Composable
 private fun TopHintStatus(content: @Composable () -> Unit) {
   Box(
@@ -297,8 +298,7 @@ private fun FindCourseViewModel.SearchState.contentKey(): Int = when (this) {
   FindCourseViewModel.SearchState.Idle -> 0
   FindCourseViewModel.SearchState.Loading -> 1
   FindCourseViewModel.SearchState.Empty -> 2
-  is FindCourseViewModel.SearchState.Error -> 3
-  is FindCourseViewModel.SearchState.Success -> 4
+  is FindCourseViewModel.SearchState.Success -> 3
 }
 
 /* ---------- 跳转 ---------- */

--- a/cyxbs-pages/course/src/commonMain/kotlin/com/cyxbs/pages/course/find/viewmodel/FindCourseViewModel.kt
+++ b/cyxbs-pages/course/src/commonMain/kotlin/com/cyxbs/pages/course/find/viewmodel/FindCourseViewModel.kt
@@ -6,18 +6,26 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.viewModelScope
 import com.cyxbs.components.base.ui.BaseViewModel
+import com.cyxbs.components.config.serializable.defaultJson
 import com.cyxbs.components.config.service.impl
+import com.cyxbs.components.utils.network.ApiException
 import com.cyxbs.pages.course.api.ILinkService2
 import com.cyxbs.pages.course.find.bean.FindStuBean
 import com.cyxbs.pages.course.find.bean.FindStuHistoryEntity
 import com.cyxbs.pages.course.find.model.FindHistoryRepository
 import com.cyxbs.pages.course.find.network.FindApiService
 import com.cyxbs.pages.course.model.LinkLessonRepository
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -26,21 +34,40 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.time.Duration.Companion.milliseconds
+
+private const val SEARCH_REQUEST_TOO_FREQUENT_STATUS = 40003
+private const val SEARCH_RETRY_INITIAL_DELAY_MS = 500L
+private const val SEARCH_RETRY_MAX_DELAY_MS = 4_000L
 
 /**
  * 查找他人课表 ViewModel
  *
- * 搜索为单条响应式 flow：[query] → debounce → distinct → flatMapLatest 触发请求 →
- * 直接 stateIn 发布为 [searchState]。flatMapLatest 保证旧请求在新关键字到达时自动取消，
- * 不会卡在 Loading。
+ * 搜索为单条响应式 flow：[queryTextFieldState] → debounce → distinct → flatMapLatest 查询缓存或触发请求 →
+ * 直接 stateIn 发布为 [searchState]。flatMapLatest 保证旧请求在新关键字到达时自动取消；普通异常通过
+ * [toastEvent] 通知页面并恢复请求前内容，限流响应则在请求层自动退避重试，上层始终保持 Loading。
  *
  * @author 985892345
  * @date 2026/5/27
  */
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 class FindCourseViewModel : BaseViewModel() {
+
+  /** 按标准化搜索词缓存成功或空结果，避免重复请求后端 */
+  private val searchCache = mutableMapOf<String, SearchState>()
+
+  /** 最近一次稳定展示的内容，用于普通请求异常时恢复页面 */
+  private var retainedSearchState: SearchState = SearchState.Idle
+
+  private val _toastEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+  /** 普通搜索异常的一次性提示事件；限流异常不会发送该事件 */
+  val toastEvent: SharedFlow<String> = _toastEvent.asSharedFlow()
 
   /** 当前搜索关键字（受 UI 文本框双向绑定） */
   val queryTextFieldState = TextFieldState()
@@ -51,26 +78,92 @@ class FindCourseViewModel : BaseViewModel() {
   /** 关联人状态 */
   val linkState: StateFlow<ILinkService2.LinkStu> = LinkLessonRepository.state
 
-  /** 搜索结果状态：由 query 一路 flow 而来，网络请求通过 onStart/map/catch 整合在 flow 中 */
+  /** 搜索结果状态：由 query 一路 flow 而来，缓存命中时不会进入网络请求 */
   val searchState: StateFlow<SearchState> = snapshotFlow { queryTextFieldState.text }
-    .debounce { if (it.isEmpty()) 0.milliseconds else 300.milliseconds }
+    .debounce { if (it.isEmpty()) 0.milliseconds else 500.milliseconds }
     .map { it.trim() }
     .distinctUntilChanged()
     .flatMapLatest { q -> searchFlow(q.toString()) }
     .stateIn(viewModelScope, SharingStarted.Eagerly, SearchState.Idle)
 
+  /**
+   * 查询单个标准化搜索词。
+   *
+   * 缓存只记录后端已确认的成功/空结果；普通异常恢复本次请求前的页面内容并发出 toast，业务状态
+   * 40003 表示请求被后端限流，此时不提示错误，并在当前请求中自动退避重试。重试期间不产生新的页面状态，
+   * 上层会保持转圈；搜索词变化时 [flatMapLatest] 会取消等待和旧请求。
+   */
   private fun searchFlow(q: String): Flow<SearchState> {
-    if (q.isEmpty()) return flowOf(SearchState.Idle)
+    if (q.isEmpty()) {
+      retainedSearchState = SearchState.Idle
+      return flowOf(SearchState.Idle)
+    }
+    searchCache[q]?.let { cachedState ->
+      retainedSearchState = cachedState
+      return flowOf(cachedState)
+    }
+    val stateBeforeRequest = retainedSearchState
     return flow { emit(FindApiService::class.impl().getStudents(q)) }
       .map { wrapper ->
         wrapper.throwApiExceptionIfFail()
         wrapper.data
       }
+      .retryWhen { throwable, attempt ->
+        if (throwable.isRequestTooFrequent()) {
+          delay(searchRetryDelayMillis(attempt).milliseconds)
+          true
+        } else {
+          false
+        }
+      }
       .map { list ->
         if (list.isEmpty()) SearchState.Empty else SearchState.Success(list)
       }
+      .map { state ->
+        searchCache[q] = state
+        retainedSearchState = state
+        state
+      }
       .onStart { emit(SearchState.Loading) }
-      .catch { e -> emit(SearchState.Error(e.message ?: "网络似乎开小差了")) }
+      .catch { throwable ->
+        _toastEvent.emit(throwable.toSearchToastMessage())
+        emit(stateBeforeRequest)
+      }
+  }
+
+  /**
+   * 计算限流重试间隔：500ms、1s、2s、4s，之后保持 4s，避免持续限流时频繁请求后端。
+   */
+  private fun searchRetryDelayMillis(attempt: Long): Long {
+    val multiplier = 1L shl attempt.coerceAtMost(3).toInt()
+    return (SEARCH_RETRY_INITIAL_DELAY_MS * multiplier).coerceAtMost(SEARCH_RETRY_MAX_DELAY_MS)
+  }
+
+  /**
+   * 从业务异常或 HTTP 异常响应体中识别后端限流状态。
+   *
+   * HTTP 状态码不是判断依据；即使传输层返回 429，也只认响应 JSON 中的业务 `status=40003`。
+   */
+  private suspend fun Throwable.isRequestTooFrequent(): Boolean = when (this) {
+    is ApiException -> status == SEARCH_REQUEST_TOO_FREQUENT_STATUS
+    is ResponseException -> responseBusinessStatus() == SEARCH_REQUEST_TOO_FREQUENT_STATUS
+    else -> false
+  }
+
+  /** 读取 Ktor 异常携带的响应体并提取业务状态，解析失败时按普通异常处理。 */
+  private suspend fun ResponseException.responseBusinessStatus(): Int? {
+    val body = runCatching { response.bodyAsText() }.getOrNull()
+      ?.takeIf { it.isNotBlank() }
+      ?: message.orEmpty().substringAfterLast(". Text: ", missingDelimiterValue = "")
+    return runCatching {
+      defaultJson.parseToJsonElement(body).jsonObject["status"]?.jsonPrimitive?.int
+    }.getOrNull()
+  }
+
+  /** 优先展示后端业务提示，其余异常沿用原异常信息。 */
+  private fun Throwable.toSearchToastMessage(): String = when (this) {
+    is ApiException -> info
+    else -> message ?: "网络似乎开小差了"
   }
 
   /** 选中一个搜索结果时调用，写入历史 */
@@ -100,6 +193,5 @@ class FindCourseViewModel : BaseViewModel() {
     data object Loading : SearchState
     data object Empty : SearchState
     data class Success(val list: List<FindStuBean>) : SearchState
-    data class Error(val message: String) : SearchState
   }
 }


### PR DESCRIPTION
## 改动内容

- 为查课搜索增加结果缓存，重复搜索相同内容时直接复用成功或空结果，不再请求后端。
- 根据响应体中的业务 `status=40003` 识别限流，不依赖 HTTP 状态码。
- 限流后在请求链内部自动退避重试，期间页面持续显示加载状态；修改搜索词时会取消旧请求。
- 其他请求异常改为 toast 提示，并保留请求前的页面内容。
- 临时注释 Desktop WebView/JCEF 相关配置，规避 JBR JCEF 与 Maven JCEF 不一致导致的编译问题，待后续 @generalio  修复。
